### PR TITLE
Replace Node.js’s stream with readable-stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 "use strict"
-var stream = require("stream");
+var stream = require("readable-stream");
 var EventEmitter = require("events").EventEmitter
 var util = require("util")
 var delegate = require("delegates")

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "tap": "^0.4.13"
   },
   "dependencies": {
-    "delegates": "^0.1.0"
+    "delegates": "^0.1.0",
+    "readable-stream": "^1.0.33"
   }
 }

--- a/test/trackerstream.js
+++ b/test/trackerstream.js
@@ -1,7 +1,7 @@
 "use strict"
 var test = require("tap").test
 var util = require("util")
-var stream = require("stream")
+var stream = require("readable-stream")
 var TrackerStream = require("../index.js").TrackerStream
 
 var timeoutError = new Error("timeout")


### PR DESCRIPTION
Replaces Node.js’s core `stream` module with [`readable-stream`](https://github.com/iojs/readable-stream). Quoting its `README.md`:

> If you want to guarantee a stable streams base, regardless of what version of Node you, or the users of your libraries are using, use readable-stream only and avoid the "stream" module in Node-core.

I did this mainly to easily [add support for Node.js v0.8](https://github.com/iarna/are-we-there-yet/issues/1), though, it has some other nice benefits.

Fixes #1.