### PR TITLE
Fix an unexpected error thrown by TrackerGroup#finish

### DIFF
--- a/test/trackergroup.js
+++ b/test/trackergroup.js
@@ -94,3 +94,15 @@ test('cycles', function (t) {
     }
   }
 })
+
+test('should properly handle finish calls when the group contains a stream', function (t) {
+  var track = new TrackerGroup('test')
+  track.newStream('test-stream', 100)
+  try {
+    track.finish()
+    t.pass('did not error on `finish()` call')
+  } catch (e) {
+    t.fail('threw error on `finish()` call')
+  }
+  t.end()
+})

--- a/tracker-stream.js
+++ b/tracker-stream.js
@@ -33,3 +33,4 @@ TrackerStream.prototype._flush = function (cb) {
 delegate(TrackerStream.prototype, 'tracker')
   .method('completed')
   .method('addWork')
+  .method('finish')


### PR DESCRIPTION
`TrackerGroup#finish` attempts to call the `finish` method on all of
its children. This worked for `Tracker` and `TrackerGroup` instances, but
failed on `TrackerStream` objects as they do not expose a `finish`
method.

This changeset exposes a `finish` method on TrackerStream instances by
adding "finish" to the method delegation list so any calls will
properly delegate to the underlying tracker instance.